### PR TITLE
Integrated node-pre-gyp for pre-built binaries, resolves #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 npm-debug.log
 .nyc*
 coverage
+lib/binding

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+*
+!API.md
+!example/*
+!lib/*.js
+!LICENSE
+!package.json
+!test

--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,4 @@
 !lib/*.js
 !LICENSE
 !package.json
-!test
+!test/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 
+env:
+  global:
+    - secure: "R7uk+cduLPmjuUyzLCyaYkApE+WNIMrmvCy9cZxGy6N0HwOGnXt8dFgiZs6xB8PkePV2Q1sq0bO6QF8PT4GnnevjQtZb/BvARJtD2VfyI7y10t/hhKkK97Cx55GKKn+4M3hADSKfIphBHe4ZvUvA5gmswDW8AoQ4Lr53/6XK1msAxUa2XZHyg1D1F8jikWmQTcgyEw+8mF0BULWaKbzRhxiOsb2u9YTvBiMph/luf/sSOC18ZDN4MMSJshSq2UTH40Sz/8/ugjEMz7gFvMq+CDmJWYA68KiCuIB0Wx+UT77xzRH1LuIBAusVnkuBvKS83EnIHPjRkZ/5CAjyo5nTLPVwFBUyT1N5Pk8Mwbpe6rmtxqPbjTa0IoM+2WPxjYTbBWcr9HhtTp/sTRdKLLMYuj9aOT+D9LLg+dYepgfFoE84EkVu0eeGxSX+/P7mvaKaWEc/4HTS3AAStzWw5fM++x6zGmy6ru6s9v1wmFq89OYCB9Wrv+MpRjrurYw3C8n/WJR6Qyh7kIu1mjLcYM61axSULe8eET1vR2sAsbvgbwyxZIHHs6Ur1gS4s0cwqALAuuotwDuDAytK5X7MNYsZkJ6dHRw9gz107+ee4HeogW6TnNIip6htaUBPR6e9HGhJrMtK61LznGxyZrfaFqbj9FuI4mat0XJci8OZmFXJn68="
+    - secure: "JV6xOo1YVqUUlsa/za7BGuYZj//y5vg7Dgcn6v0MJzF+ZxIM5maGh6iA3mhiCIUetHVwwlqjJg8ZaZ8vFcWRcx27+591xgTSJWrPhgnbqcNupDCGoexiqUUzfgOtkuDowmRp4wz2e5uUpox4Gm6gmJkEt1nUs+/gsk7fjDoChSTGgJ2eASiLgzY2Hg38iT5IiZMx//FWw0uQnYCtPR0vtGYdgT8aSMXnVSsFqvpUJBUnQj4R93eJbQiXUN6SCRpjvd536JOgd+ud+zm7QTvzmRKSgag31XDKNjD/1SK3zzhkfNL/1T7Kr3rCdluxa0RO2c3eLiN6rkjelVtFcRvj7zwJvZ2BJ5WLWILtvbvvCmNzI43v+8RandYiWm8CWxVwUt3Cw+xzG0DblO+TCT8P9DipljI5zOeEBh6Tc920zb0P45E5jnxu6oxS2sOV/K2oyFu5152JXI4u24xVxMeVd9cxOzd4Jpxn5pe/m7RPeEDTpHA28RBTjA98kysR3aUBsfF5I/IrxkT8e9XnMuAOGaVgaAzGRAjL481H8CMIkQT14hO3+jqPKcn1scgDOGxw+Ijujdix9BtVt5/pEokfXYd2KXBmgDAPTBqfgkabPDXoNv0iXDdkQVl0924s0Jq/Io1DbjIIS+zezrPOwryVBsPjRYfWsjwl9Nv1KjK+yeQ="
+
 addons:
   apt:
     sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0' ]
@@ -10,6 +15,7 @@ install:
 
 script:
   - npm test
+  - ./scripts/publish.sh
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -11,25 +11,25 @@ We recommend using the [Mapbox Directions Matrix](https://www.mapbox.com/api-doc
 
 [![Example](https://raw.githubusercontent.com/mapbox/node-or-tools/master/example/solution.png?token=AAgLiX1m1BDa8ll0Lsk0xc6fz0RgQA1Lks5Y-VmAwA)](https://github.com/mapbox/node-or-tools/blob/master/example/solution.geojson)
 
-### Installing
+### Quick Start
 
-Update your Node.js and NPM versions via [nvm](https://github.com/creationix/nvm).
+    npm install node_or_tools
 
-    nvm install 4
-    nvm use 4
+```c++
+var ortools = require('node_or_tools')
 
-Then
+var VRP = new ortools.VRP(solverOpts);
 
-    npm install
+VRP.Solve(searchOpts, function (err, solution) {
+  // ..
+});
+```
 
-or if you are root
-
-    npm install --unsafe-perm
+See [API.md](API.md) for interface documentation and [the example](./example/README.md) for a small self-contained example.
 
 We ship pre-built native binaries (for Node.js LTS 4 and 6 on Linux and macOS).
-You will need a compatible C++ stdlib. Building from source is supported, too:
-
-    npm install --build-from-source
+You will need a compatible C++ stdlib, see below if you encounter issues.
+Building from source is supported via the `--build-from-source` flag.
 
 #### Ubuntu 14.04
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ or if you are root
 
     npm install --unsafe-perm
 
-We ship pre-built native binaries for which you will need a compatible C++ stdlib.
+We ship pre-built native binaries (for Node.js LTS 4 and 6 on Linux and macOS).
+You will need a compatible C++ stdlib. Building from source is supported, too:
+
+    npm install --build-from-source
 
 #### Ubuntu 14.04
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,16 +1,14 @@
 {
-    "includes": [ "common.gypi" ],
-    "variables": {
-      # includes we don't want warnings for.
-      # As a variable to make easy to pass to
-      # cflags (linux) and xcode (mac)
-      "system_includes": [
-        "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")",
-        "-isystem <(module_root_dir)/mason_packages/.link/include",
-        "-isystem <(module_root_dir)/mason_packages/.link/include/or-tools"
+    'includes': [ 'common.gypi' ],
+    'variables': {
+      # Includes we don't want warnings for.
+      'system_includes': [
+        '-isystem <(module_root_dir)/<!(node -e \'require("nan")\')',
+        '-isystem <(module_root_dir)/mason_packages/.link/include',
+        '-isystem <(module_root_dir)/mason_packages/.link/include/or-tools'
       ]
     },
-    "targets": [
+    'targets': [
         {
           'target_name': 'action_before_build',
           'type': 'none',
@@ -18,34 +16,35 @@
           'actions': [
             {
               'action_name': 'install-deps',
-              'inputs': ['./install-deps.sh'],
+              'inputs': ['./scripts/install-deps.sh'],
               'outputs': ['./mason_packages'],
-              'action': ['./install-deps.sh']
+              'action': ['./scripts/install-deps.sh']
             }
           ]
         },
         {
-            "target_name": "node_or_tools",
+            'target_name': '<(module_name)',
+            'product_dir': '<(module_path)',
             'dependencies': [ 'action_before_build' ],
-            "link_settings": {
-                "libraries": ["-lortools"],
-                "library_dirs": [
-                  "<(module_root_dir)/mason_packages/.link/lib"
+            'link_settings': {
+                'libraries': ['-lortools'],
+                'library_dirs': [
+                  '<(module_root_dir)/mason_packages/.link/lib'
                 ]
             },
-            "sources": [
-                "src/main.cc",
-                "src/tsp.cc",
-                "src/vrp.cc",
+            'sources': [
+                'src/main.cc',
+                'src/tsp.cc',
+                'src/vrp.cc',
             ],
             'ldflags': [
                 '-Wl,-z,now'
             ],
-            "conditions": [
-                ["OS == 'linux'",{
-                    'ldflags': ["-Wl,-z,origin -Wl,-rpath=\$$ORIGIN"],
+            'conditions': [
+                ['OS == "linux"', {
+                    'ldflags': ['-Wl,-z,origin -Wl,-rpath=\$$ORIGIN'],
                     'cflags': [
-                        "<@(system_includes)"
+                        '<@(system_includes)'
                     ]
                 }]
             ],
@@ -54,7 +53,7 @@
                   '-Wl,-bind_at_load'
                 ],
                 'OTHER_CPLUSPLUSFLAGS': [
-                    "<@(system_includes)"
+                    '<@(system_includes)'
                 ],
                 'GCC_ENABLE_CPP_RTTI': 'YES',
                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',

--- a/cloudformation/ci.template
+++ b/cloudformation/ci.template
@@ -1,0 +1,75 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "user for publishing to s3://mapbox-node-binary/node_or_tools",
+    "Resources": {
+        "User": {
+            "Type": "AWS::IAM::User",
+            "Properties": {
+                "Policies": [
+                    {
+                        "PolicyName": "list",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "s3:ListBucket"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "arn:aws:s3:::mapbox-node-binary",
+                                    "Condition": {
+                                        "StringLike": {
+                                            "s3:prefix": [
+                                                "node_or_tools/*"
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "publish",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "s3:DeleteObject",
+                                        "s3:GetObject",
+                                        "s3:GetObjectAcl",
+                                        "s3:PutObject",
+                                        "s3:PutObjectAcl"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "arn:aws:s3:::mapbox-node-binary/node_or_tools/*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "AccessKey": {
+            "Type": "AWS::IAM::AccessKey",
+            "Properties": {
+                "UserName": {
+                    "Ref": "User"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "AccessKeyId": {
+            "Value": {
+                "Ref": "AccessKey"
+            }
+        },
+        "SecretAccessKey": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "AccessKey",
+                    "SecretAccessKey"
+                ]
+            }
+        }
+    }
+}

--- a/cloudformation/ci.template.js
+++ b/cloudformation/ci.template.js
@@ -1,0 +1,59 @@
+var cf = require('@mapbox/cloudfriend');
+var package_json = require('../package.json')
+
+module.exports = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'user for publishing to s3://mapbox-node-binary/' + package_json.name,
+  Resources: {
+    User: {
+      Type: 'AWS::IAM::User',
+      Properties: {
+        Policies: [
+          {
+            PolicyName: 'list',
+            PolicyDocument: {
+              Statement: [
+                {
+                  Action: ['s3:ListBucket'],
+                  Effect: 'Allow',
+                  Resource: 'arn:aws:s3:::mapbox-node-binary',
+                  Condition : {
+                    StringLike : {
+                      "s3:prefix": [ package_json.name + "/*"]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            PolicyName: 'publish',
+            PolicyDocument: {
+              Statement: [
+                {
+                  Action: ['s3:DeleteObject', 's3:GetObject', 's3:GetObjectAcl', 's3:PutObject', 's3:PutObjectAcl'],
+                  Effect: 'Allow',
+                  Resource: 'arn:aws:s3:::mapbox-node-binary/' + package_json.name + '/*'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    AccessKey: {
+      Type: 'AWS::IAM::AccessKey',
+      Properties: {
+        UserName: cf.ref('User')
+      }
+    }
+  },
+  Outputs: {
+    AccessKeyId: {
+      Value: cf.ref('AccessKey')
+    },
+    SecretAccessKey: {
+      Value: cf.getAtt('AccessKey', 'SecretAccessKey')
+    }
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('.');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./binding/node_or_tools.node');

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "node_or_tools",
   "version": "0.0.1",
   "description": "Native module for the or-tools TSP / VRP solvers",
+  "url": "https://github.com/mapbox/node-or-tools",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mapbox/node-or-tools.git"
+  },
   "keywords": [
     "addon",
     "native",
@@ -9,14 +14,27 @@
   ],
   "author": "Daniel J. Hofmann",
   "license": "MIT",
-  "main": "./build/Release/node_or_tools",
+  "main": "./lib/index.js",
   "scripts": {
+    "prepublish": "npm ls",
+    "install": "node-pre-gyp install --fallback-to-build",
+    "clean": "node-pre-gyp clean",
     "test": "tap -Rspec test/*.js"
   },
   "dependencies": {
-    "nan": "^2.6"
+    "nan": "^2.6",
+    "node-pre-gyp": "^0.6.34"
   },
   "devDependencies": {
+    "aws-sdk": "^2.42.0",
     "tap": "^10.3"
+  },
+  "bundledDependencies": ["node-pre-gyp"],
+  "binary": {
+    "module_name": "node_or_tools",
+    "module_path": "./lib/binding/",
+    "host": "https://mapbox-node-binary.s3.amazonaws.com",
+    "remote_path": "./{name}/v{version}/{configuration}/",
+    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   }
 }

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -27,5 +27,8 @@ fi
 ./third_party/mason/mason install or-tools ${ORTOOLS_RELEASE}
 ./third_party/mason/mason link or-tools ${ORTOOLS_RELEASE}
 
-mkdir -p build/Release/
-cp mason_packages/.link/lib/libortools.* build/Release/
+mkdir -p ./build/Release/
+cp ./mason_packages/.link/lib/libortools.* ./build/Release/
+
+mkdir -p ./lib/binding/
+cp ./mason_packages/.link/lib/libortools.* ./lib/binding/

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# See https://github.com/mapbox/node-cpp-skel
+
+set -eu
+set -o pipefail
+
+export COMMIT_MESSAGE=$(git log --format=%B --no-merges -n 1 | tr -d '\n')
+
+# `is_pr_merge` is designed to detect if a gitsha represents a normal
+# push commit (to any branch) or whether it represents travis attempting
+# to merge between the origin and the upstream branch.
+# For more details see: https://docs.travis-ci.com/user/pull-requests
+function is_pr_merge() {
+  # Get the commit message via git log
+  # This should always be the exactly the text the developer provided
+  local COMMIT_LOG=${COMMIT_MESSAGE}
+
+  # Get the commit message via git show
+  # If the gitsha represents a merge then this will
+  # look something like "Merge e3b1981 into 615d2a3"
+  # Otherwise it will be the same as the "git log" output
+  export COMMIT_SHOW=$(git show -s --format=%B | tr -d '\n')
+
+  if [[ "${COMMIT_LOG}" != "${COMMIT_SHOW}" ]]; then
+     echo true
+  fi
+}
+
+# `publish` is used to publish binaries to s3 via commit messages if:
+# - the commit message includes [publish binary]
+# - the commit message includes [republish binary]
+# - the commit is not a pr_merge (checked with `is_pr_merge` function)
+function publish() {
+  echo "dumping binary meta..."
+  ./node_modules/.bin/node-pre-gyp reveal --loglevel=error $@
+
+  echo "determining publishing status..."
+
+  if [[ $(is_pr_merge) ]]; then
+      echo "Skipping publishing because this is a PR merge commit"
+  else
+      echo "Commit message: ${COMMIT_MESSAGE}"
+
+      if [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then
+          echo "Publishing"
+          ./node_modules/.bin/node-pre-gyp package publish $@
+      elif [[ ${COMMIT_MESSAGE} =~ "[republish binary]" ]]; then
+          echo "Re-Publishing"
+          ./node_modules/.bin/node-pre-gyp package unpublish publish $@
+      else
+          echo "Skipping publishing since we did not detect either [publish binary] or [republish binary] in commit message"
+      fi
+  fi
+}
+
+function usage() {
+  >&2 echo "Usage"
+  >&2 echo ""
+  >&2 echo "$ ./scripts/publish.sh <args>"
+  >&2 echo ""
+  >&2 echo "All args are forwarded to node-pre-gyp like --debug"
+  >&2 echo ""
+  exit 1
+}
+
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+for i in "$@"
+do
+case $i in
+    -h | --help)
+    usage
+    shift
+    ;;
+    *)
+    ;;
+esac
+done
+
+publish $@

--- a/test/vrp.js
+++ b/test/vrp.js
@@ -135,7 +135,6 @@ tap.test('Test VRP', function(assert) {
   };
 
   VRP.Solve(searchOpts, function (err, solution) {
-    console.log(solution);
     assert.ifError(err, 'Solution can be found');
 
     assert.type(solution, Object, 'Solution is Object with properties');


### PR DESCRIPTION
Workflow for publishing locally - needs to be authed with aws and npm.

For binary

```
npm install --build-from-source
./node_modules/.bin/node-pre-gyp package
./node_modules/.bin/node-pre-gyp publish
```

Then publish npm package

```
npm publish
```

Tasks:
- [x] Let Travis install, package and publish binaries for {Linux,macOS} x {Node 4, Node 6} to aws
- [x] Add a `.npmignore` to not accidentally publish repo. contents to npm
- [ ] Add release docs