### PR TITLE
Fixes Pickup+Delivery: constraints need to target internal indices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node_or_tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Native module for the or-tools TSP / VRP solvers",
   "url": "https://github.com/mapbox/node-or-tools",
   "repository": {

--- a/src/vrp_worker.h
+++ b/src/vrp_worker.h
@@ -130,11 +130,14 @@ struct VRPWorker final : Nan::AsyncWorker {
     auto* solver = model.solver();
 
     for (std::int32_t atIdx = 0; atIdx < pickups.size(); ++atIdx) {
-      auto* sameRouteCt = solver->MakeEquality(model.VehicleVar(model.NodeToIndex(pickups.at(atIdx))),     //
-                                               model.VehicleVar(model.NodeToIndex(deliveries.at(atIdx)))); //
+      const auto pickupIndex = model.NodeToIndex(pickups.at(atIdx));
+      const auto deliveryIndex = model.NodeToIndex(deliveries.at(atIdx));
 
-      auto* pickupBeforeDeliveryCt = solver->MakeLessOrEqual(timeDimension.CumulVar(pickups.at(atIdx).value()),     //
-                                                             timeDimension.CumulVar(deliveries.at(atIdx).value())); //
+      auto* sameRouteCt = solver->MakeEquality(model.VehicleVar(pickupIndex),    //
+                                               model.VehicleVar(deliveryIndex)); //
+
+      auto* pickupBeforeDeliveryCt = solver->MakeLessOrEqual(timeDimension.CumulVar(pickupIndex),    //
+                                                             timeDimension.CumulVar(deliveryIndex)); //
 
       solver->AddConstraint(sameRouteCt);
       solver->AddConstraint(pickupBeforeDeliveryCt);


### PR DESCRIPTION
We accidentally used the external node indices in the time order constraint (pickup has to come before delivery). This changeset fixes this mistake.

Reaching down to the underlying constraint solver we have to translate external node indices to solver-internal indices. Otherwise the constraints might be wrong or we corrupt internal state and (in the best case) crash.

---

Needs a 1.0.1 release with binaries and npm package update. See release process [here](https://github.com/mapbox/node-or-tools#releases).