### PR TITLE
Statically link libortools.a into binary

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,10 +27,12 @@
             'product_dir': '<(module_path)',
             'dependencies': [ 'action_before_build' ],
             'link_settings': {
-                'libraries': ['-lortools'],
-                'library_dirs': [
-                  '<(module_root_dir)/mason_packages/.link/lib'
-                ]
+                'libraries': [
+                  '<(module_root_dir)/mason_packages/.link/lib/libortools.a',
+                  '<(module_root_dir)/mason_packages/.link/lib/libprotobuf.a',
+                  '<(module_root_dir)/mason_packages/.link/lib/libgflags.a',
+                  '-lz',
+                ],
             },
             'sources': [
                 'src/main.cc',
@@ -42,7 +44,6 @@
             ],
             'conditions': [
                 ['OS == "linux"', {
-                    'ldflags': ['-Wl,-z,origin -Wl,-rpath=\$$ORIGIN'],
                     'cflags': [
                         '<@(system_includes)'
                     ]

--- a/common.gypi
+++ b/common.gypi
@@ -5,7 +5,11 @@
       '-std=c++14',
       '-Wall',
       '-Wextra',
-      '-D_GLIBCXX_USE_CXX11_ABI=0'
+      '-ffunction-sections -fdata-sections',
+      '-D_GLIBCXX_USE_CXX11_ABI=0',
+    ],
+    'ldflags': [
+      '-Wl,--gc-sections'
     ],
     'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
     'configurations': {

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # Point to or-tools upstream mason package commit until we have a
 # new mason release. See https://github.com/mapbox/mason/pull/426
-MASON_RELEASE="0465138"
+MASON_RELEASE="ca9b4cb"
 SPARSEHASH_RELEASE="2.0.2"
 ORTOOLS_RELEASE="6.0"
 PROTOBUF_RELEASE="3.0.0"
@@ -28,8 +28,7 @@ fi
 ./third_party/mason/mason install or-tools ${ORTOOLS_RELEASE}
 ./third_party/mason/mason link or-tools ${ORTOOLS_RELEASE}
 
-mkdir -p ./build/Release/
-cp ./mason_packages/.link/lib/libortools.* ./build/Release/
 
-mkdir -p ./lib/binding/
-cp ./mason_packages/.link/lib/libortools.* ./lib/binding/
+# We ship debug binaries with mason but for production builds we just strip debug symbols out.
+# In case you need debug symbols just comment out the following line and `npm --build-from-source`.
+find mason_packages/ -type f -name 'libortools.*' -exec strip --strip-unneeded {} \;


### PR DESCRIPTION
Up till now we only had a dynamically linked `libortools.so` library in mason. We changed this in [this commit](https://github.com/mapbox/mason/pull/426/commits/ca9b4cbcf5bfeb3c747b90d05fa80d1bdd9c5769) upstream ([context](https://github.com/mapbox/mason/pull/426#issuecomment-309455706)) which builds both a dynamically linked as well as a statically linked library. In addition
- these libraries do include debug symbols and
- have their functions put into own sections so that our linker can discard what's not needed when building the node binaries

This makes the or-tools mason package a bit bigger in size (in the hundreds of megabytes) but now we have debug binaries available. For our release node bindings we simply strip out debug symbols _when linking the node binaries_ such that the final statically linked bindings come down to roughly ten megabytes in size.

---

If this works out we need to release v1.0.3 - see https://github.com/mapbox/node-or-tools#releases