### PR TITLE
Add src to npmignore whitelist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,4 +9,5 @@
 !test/*
 !binding.gyp
 !common.gypi
+!src/*
 !scripts/install-deps.sh


### PR DESCRIPTION
Otherwise building from source will fail if prebuild binaries are unavailable.