### PR TITLE
replace deprecated getDistances with getMatrix in example

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -62,7 +62,7 @@ function hasNoRouteFound(matrix) {
 }
 
 
-MbxClient.getDistances(locations, {profile: profile}, function(err, results) {
+MbxClient.getMatrix(locations.map(function (coord) { return { longitude: coord[0], latitude: coord[1] } }), {profile: profile}, function(err, results) {
   if (err) {
     console.error('Error: ' + err.message);
     process.exit(1);

--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,6 @@
   "author": "Daniel J. Hofmann",
   "license": "MIT",
   "dependencies": {
-    "mapbox": "^1.0.0-beta8"
+    "mapbox": "1.0.0-beta8"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,6 @@
   "author": "Daniel J. Hofmann",
   "license": "MIT",
   "dependencies": {
-    "mapbox": "^1.0.0-beta6"
+    "mapbox": "^1.0.0-beta8"
   }
 }


### PR DESCRIPTION
`mapbox-sdk-js` pushed through a breaking change in `1.0.0-beta8` replacing `getDistances` with `getMatrix`.

The example has the dependency on mapbox-sdk-js as `"mapbox": "^1.0.0-beta6"`. Due to the carrot operator and the way [semver/npm works](https://docs.npmjs.com/misc/semver), `npm install` will install the latest `1.0.0-beta9` as it assumes no breaking changes in beta version updates. Hence it breaks.

I've opened the upstream ticket https://github.com/mapbox/mapbox-sdk-js/issues/186 to try to avoid this happening next time.