### PR TITLE
Add Node.js 10.x builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
       node_js: 8
       sudo: false
       env: CC='clang-4.0' CXX='clang++-4.0'
+    - os: linux
+      node_js: 10
+      sudo: false
+      env: CC='clang-4.0' CXX='clang++-4.0'
     - os: osx
       osx_image: xcode8.2
       node_js: 4
@@ -40,3 +44,6 @@ matrix:
     - os: osx
       osx_image: xcode8.2
       node_js: 8
+    - os: osx
+      osx_image: xcode8.2
+      node_js: 10


### PR DESCRIPTION
Node.js 10.x entered active LTS today, adding builds to Travis to publish binaries for node 10.