### PR TITLE
Bump node-pre-gyp to ^0.12.0 to fix double rebuild bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "nan": "^2.6",
-    "node-pre-gyp": "^0.10.1"
+    "node-pre-gyp": "^0.12.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.42.0",


### PR DESCRIPTION
This fixes a weird double rebuild bug described here: https://github.com/mapbox/node-pre-gyp/issues/444#issuecomment-474139956